### PR TITLE
Support KWallet files with minor=1 and PBKDF2 key derivation

### DIFF
--- a/src/kwallet-dump.py
+++ b/src/kwallet-dump.py
@@ -4,17 +4,21 @@ import getpass
 import sys
 from kwallet_dump import kwallet, reader
 
-def parse_filename():
+def parse_args():
     parser = argparse.ArgumentParser(description='Dump a .kwl kwallet file')
     parser.add_argument('filename', help='Location of kwallet file')
+    parser.add_argument(
+        'salt_filename',
+        help='Location of salt file for PBKDF2-derived files (since KDE 4.13)',
+        nargs='?',
+    )
 
-    args = parser.parse_args()
-    return args.filename
+    return parser.parse_args()
 
 def main():
-    filename = parse_filename()
+    args = parse_args()
     try:
-        wallet = reader.KWalletReader(filename)
+        wallet = reader.KWalletReader(args.filename, args.salt_filename)
     except reader.InvalidKWallet as e:
         print('Invalid file error: ' + str(e))
         sys.exit(1)


### PR DESCRIPTION
KWallet added support for PBKDF2-HMAC-SHA512 key derivation, which is the
default in newer 4.x series.

Magic numbers in this revision are taken from revision
0080edf3bc11a6f7c209e990b2b4ceb6be8b9aad of git://anongit.kde.org/kwallet.git.
This is a 5.x repository, but I have found it sufficient to parse my KWallet
file from KDE 4.13.
